### PR TITLE
fix for api changes in jade and stylus

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   , "underscore.date": "0.5.x"
   , "stextile": "latest"
   , "nodewatch": "latest"
-  , "jade": ">= 0.13.0"
-  , "stylus": ">= 0.13.7"
+  , "jade": "0.13.0"
+  , "stylus": "0.13.7"
   }
 , "devDependencies": {
     "dox": "latest"


### PR DESCRIPTION
locking the versions to the ones you created pop against fixes it if you want to pull in
