### PR TITLE
Fix paginator page count

### DIFF
--- a/lib/paginator.js
+++ b/lib/paginator.js
@@ -18,7 +18,7 @@ function Paginator(perPage, items) {
   this.previousPage = 0;
   this.nextPage = 2;
   this.page = 1;
-  this.pages = Math.round(this.allItems.length / this.perPage) + 1;
+  this.pages = Math.ceil(this.allItems.length / this.perPage);
 }
 
 /**

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -45,7 +45,7 @@ exports['test pagination template generation'] = function() {
   paginator = new Paginator(config.perPage, siteBuilder.posts);
   html = helpers.paginate.apply(siteBuilder, [paginator]);
   
-  expected = '\n<div class="pages"><span class="prev_next"><strong class="page">1</strong><a href="/page2/" class="page">2</a><a href="/page3/" class="page">3</a><a href="/page4/" class="page">4</a><a href="/page5/" class="page">5</a><a href="/page2/" class="next">Next</a><span>&rarr;</span></span>\n</div>';
+  expected = '\n<div class="pages"><span class="prev_next"><strong class="page">1</strong><a href="/page2/" class="page">2</a><a href="/page3/" class="page">3</a><a href="/page4/" class="page">4</a><a href="/page2/" class="next">Next</a><span>&rarr;</span></span>\n</div>';
 
   assert.equal(html, expected);
 };


### PR DESCRIPTION
Prevent the creation of an empty last page in the `Paginator`. Previously, the pagination would only be correct when the calculation had been rounded down.

In `test`, 20 posts at 5 posts per page should now generate 4 pages. 
